### PR TITLE
Remove unnecessary white space

### DIFF
--- a/src/data/examples/en/19_Typography/02_Text_Rotation.js
+++ b/src/data/examples/en/19_Typography/02_Text_Rotation.js
@@ -1,5 +1,5 @@
 /*
- * @name Text Rotation 
+ * @name Text Rotation
  * @description Draws letters to the screen and rotates them at different angles.
  *  (ported from https://processing.org/examples/textrotation.html) 
  */


### PR DESCRIPTION
Remove the white space at the end of line 2 that caused the link to this example to be built incorrectly.

Fixes #1029